### PR TITLE
Add `nvim-ts-context-commentstring` to correctly set the comment string based on cursor not filetype

### DIFF
--- a/lua/init.lua
+++ b/lua/init.lua
@@ -107,6 +107,7 @@ plug.register('kyazdani42/nvim-tree.lua')
 plug.register('norcalli/nvim-colorizer.lua')
 plug.register('nvim-treesitter/nvim-treesitter', { ['do'] = ':TSUpdate' })
 plug.register('nvim-treesitter/nvim-treesitter-context')
+plug.register('JoosepAlviste/nvim-ts-context-commentstring')
 
 -- LSP
 plug.register('jose-elias-alvarez/null-ls.nvim')
@@ -307,11 +308,18 @@ require('nvim-treesitter.configs').setup({
     -- Instead of true it can also be a list of languages
     additional_vim_regex_highlighting = false,
   },
-})
 
-require('mini.cursorword').setup({
-  -- Delay (in ms) between when cursor moved and when highlighting appeared
-  delay = 300,
+  autotag = {
+    enable = true,
+  },
+
+  indent = {
+    enable = true
+  },
+
+  context_commentstring = {
+    enable = true
+  },
 })
 
 require('.lsp')


### PR DESCRIPTION
it is based on treesitter. It is useful on files that include multiple programming languages in the same file, like HTML including inline JS or CSS.